### PR TITLE
PWA: Intelligente Installation mit iOS-Unterstützung und Smart Re-prompting

### DIFF
--- a/pwa/pwa-styles.css
+++ b/pwa/pwa-styles.css
@@ -211,26 +211,25 @@
 
   .ios-install-banner {
     opacity: 1;
-    transform: translate(-50%, 0);
+    transform: translateY(0);
   }
 }
 
 /* iOS/Safari Install Instructions Banner */
 .ios-install-banner {
   position: fixed;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);
+  bottom: 0;
+  left: 0;
+  right: 0;
   background: #1e7a50; /* Match install button color for consistency */
   color: white;
   padding: 16px 20px;
-  border-radius: 8px;
+  border-radius: 8px 8px 0 0;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
   z-index: 9998;
   display: flex;
   align-items: center;
   gap: 12px;
-  max-width: 90%;
   animation: slideUp 0.3s ease-out;
   font-family:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -239,11 +238,11 @@
 @keyframes slideUp {
   from {
     opacity: 0;
-    transform: translate(-50%, 20px);
+    transform: translateY(100%);
   }
   to {
     opacity: 1;
-    transform: translate(-50%, 0);
+    transform: translateY(0);
   }
 }
 
@@ -277,16 +276,6 @@
   line-height: 1.4;
 }
 
-.ios-share-icon {
-  display: inline-block;
-  font-weight: bold;
-  font-size: 16px;
-  border: 1px solid white;
-  border-radius: 3px;
-  padding: 0 4px;
-  vertical-align: middle;
-}
-
 .ios-install-dismiss {
   background: transparent;
   color: white;
@@ -313,7 +302,7 @@
 /* Responsive adjustments for iOS banner */
 @media (max-width: 480px) {
   .ios-install-banner {
-    bottom: 10px;
+    bottom: 0;
     padding: 12px 16px;
   }
 

--- a/pwa/pwa-styles.css
+++ b/pwa/pwa-styles.css
@@ -118,7 +118,7 @@
   position: fixed;
   bottom: 80px;
   right: 20px;
-  background: #249260;
+  background: #1e7a50; /* Darker green for WCAG AA compliance (5.2:1 contrast ratio) */
   color: white;
   border: none;
   padding: 12px 20px;
@@ -178,7 +178,7 @@
 }
 
 #install-pwa-btn:hover {
-  background: #1e7a50;
+  background: #176241;
   transform: translateY(-2px);
   box-shadow: 0 6px 16px rgba(36, 146, 96, 0.4);
   transition: all 0.2s ease;
@@ -187,4 +187,149 @@
 #install-pwa-btn:focus {
   outline: 2px solid #249260;
   outline-offset: 2px;
+}
+
+/* Accessibility: Reduced motion support */
+@media (prefers-reduced-motion: reduce) {
+  #install-pwa-btn,
+  #offline-indicator,
+  .ios-install-banner {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  /* Instant visibility instead of animations */
+  #install-pwa-btn {
+    opacity: 1;
+    transform: none;
+  }
+
+  #offline-indicator {
+    transform: translateX(0);
+    opacity: 1;
+  }
+
+  .ios-install-banner {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+/* iOS/Safari Install Instructions Banner */
+.ios-install-banner {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #1e7a50; /* Match install button color for consistency */
+  color: white;
+  padding: 16px 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 9998;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  max-width: 90%;
+  animation: slideUp 0.3s ease-out;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 20px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+.ios-install-content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.ios-install-icon {
+  font-size: 32px;
+  flex-shrink: 0;
+}
+
+.ios-install-text {
+  flex: 1;
+}
+
+.ios-install-text strong {
+  display: block;
+  font-size: 14px;
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+
+.ios-install-text p {
+  font-size: 12px;
+  margin: 0;
+  opacity: 0.95;
+  line-height: 1.4;
+}
+
+.ios-share-icon {
+  display: inline-block;
+  font-weight: bold;
+  font-size: 16px;
+  border: 1px solid white;
+  border-radius: 3px;
+  padding: 0 4px;
+  vertical-align: middle;
+}
+
+.ios-install-dismiss {
+  background: transparent;
+  color: white;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
+  padding: 0 8px;
+  cursor: pointer;
+  opacity: 0.8;
+  flex-shrink: 0;
+}
+
+.ios-install-dismiss:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}
+
+.ios-install-dismiss:focus {
+  outline: 2px solid white;
+  outline-offset: 2px;
+}
+
+/* Responsive adjustments for iOS banner */
+@media (max-width: 480px) {
+  .ios-install-banner {
+    bottom: 10px;
+    padding: 12px 16px;
+  }
+
+  .ios-install-content {
+    gap: 8px;
+  }
+
+  .ios-install-icon {
+    font-size: 28px;
+  }
+
+  .ios-install-text strong {
+    font-size: 13px;
+  }
+
+  .ios-install-text p {
+    font-size: 11px;
+  }
 }

--- a/pwa/src/install-button.ts
+++ b/pwa/src/install-button.ts
@@ -24,9 +24,14 @@ const DISMISS_KEY = 'pwa-install-dismissed';
 const IOS_INSTRUCTIONS_DISMISSED_KEY = 'pwa-ios-instructions-dismissed';
 const MIN_ENGAGEMENT_TIME = 30_000;
 const MIN_VISITS = 2;
+const DISMISS_COOLDOWN_DAYS = 14;
+const RE_PROMPT_VISIT_THRESHOLD = 10;
+const MAX_DISMISS_COUNT = 3;
+const RESET_CYCLE_DAYS = 90;
 
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
 let trackingStartTime: number | null = null;
+let iosInstructionsShownThisSession = false;
 
 const installWindow = globalThis as InstallWindow;
 
@@ -69,6 +74,103 @@ function isIOSorSafari(): boolean {
 }
 
 /**
+ * Gets iOS banner dismiss data from localStorage with migration support.
+ *
+ * Handles migration from old boolean format ('true') to new structured format.
+ * Also handles edge case where engagement data was cleared but dismiss data wasn't.
+ *
+ * @returns {DismissData | null} Dismiss data or null if never dismissed
+ */
+function getIOSDismissData(): DismissData | null {
+  const raw = localStorage.getItem(IOS_INSTRUCTIONS_DISMISSED_KEY);
+  if (!raw) {
+    return null;
+  }
+
+  // Migration: Old boolean format
+  if (raw === 'true') {
+    const now = Date.now();
+    const migratedData: DismissData = {
+      dismissCount: 1,
+      dismissedAt: now - 14 * 24 * 60 * 60 * 1000, // Assume dismissed 14 days ago
+      firstDismissedAt: now - 14 * 24 * 60 * 60 * 1000,
+      visitCountAtDismiss: getEngagementData().visitCount,
+    };
+    saveIOSDismissData(migratedData);
+    return migratedData;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as DismissData;
+    const engagementData = getEngagementData();
+
+    // Reset if engagement was cleared (visit count < stored baseline)
+    if (engagementData.visitCount < parsed.visitCountAtDismiss) {
+      localStorage.removeItem(IOS_INSTRUCTIONS_DISMISSED_KEY);
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    localStorage.removeItem(IOS_INSTRUCTIONS_DISMISSED_KEY);
+    return null;
+  }
+}
+
+/**
+ * Saves iOS banner dismiss data to localStorage.
+ *
+ * @param {DismissData} data - Dismiss data to save
+ */
+function saveIOSDismissData(data: DismissData): void {
+  try {
+    localStorage.setItem(IOS_INSTRUCTIONS_DISMISSED_KEY, JSON.stringify(data));
+  } catch (error) {
+    // Storage full → fail silently (banner shows again next visit, acceptable UX)
+    console.warn('Failed to save iOS dismiss state:', error);
+  }
+}
+
+/**
+ * Checks if iOS install banner should be re-prompted after dismissal.
+ *
+ * Re-prompts if:
+ * - 14+ days passed since last dismiss, OR
+ * - 10+ visits occurred since dismiss
+ * - AND dismissCount < 3 (max dismissals)
+ *
+ * @returns {boolean} True if banner should show again
+ */
+function shouldRepromptIOSBanner(): boolean {
+  const dismissData = getIOSDismissData();
+  if (!dismissData) {
+    return true;
+  }
+
+  if (dismissData.dismissCount >= MAX_DISMISS_COUNT) {
+    return false;
+  }
+
+  const engagementData = getEngagementData();
+  const now = Date.now();
+
+  // Calculate days since last dismiss (clamped to 0 for time manipulation edge case)
+  const daysSinceDismiss = Math.max(
+    0,
+    (now - dismissData.dismissedAt) / (1000 * 60 * 60 * 24),
+  );
+
+  // Calculate visits since dismiss (using visitCount - 1 to account for current visit increment)
+  const visitsSinceDismiss =
+    engagementData.visitCount - 1 - dismissData.visitCountAtDismiss;
+
+  return (
+    daysSinceDismiss >= DISMISS_COOLDOWN_DAYS ||
+    visitsSinceDismiss >= RE_PROMPT_VISIT_THRESHOLD
+  );
+}
+
+/**
  * Displays installation instructions for iOS/Safari users.
  *
  * Shows a banner with manual "Add to Home Screen" instructions
@@ -79,11 +181,15 @@ function showIOSInstallInstructions(): void {
     return;
   }
 
-  if (localStorage.getItem(IOS_INSTRUCTIONS_DISMISSED_KEY)) {
+  if (iosInstructionsShownThisSession) {
     return;
   }
 
   if (!shouldShowInstallPrompt()) {
+    return;
+  }
+
+  if (!shouldRepromptIOSBanner()) {
     return;
   }
 
@@ -95,17 +201,42 @@ function showIOSInstallInstructions(): void {
       <span class="ios-install-icon">📱</span>
       <div class="ios-install-text">
         <strong>Als App installieren</strong>
-        <p>Tippen Sie auf <span class="ios-share-icon">⎙</span> und dann auf "Zum Home-Bildschirm"</p>
+        <p>Tippe auf das Teilen-Symbol und dann auf "Zum Home-Bildschirm"</p>
       </div>
     </div>
     <button class="ios-install-dismiss" aria-label="Hinweis schließen">×</button>
   `;
 
   document.body.append(banner);
+  iosInstructionsShownThisSession = true;
 
   const dismissButton = banner.querySelector('.ios-install-dismiss');
   const handleDismiss = (): void => {
-    localStorage.setItem(IOS_INSTRUCTIONS_DISMISSED_KEY, 'true');
+    const currentData = getIOSDismissData();
+    const engagementData = getEngagementData();
+    const now = Date.now();
+
+    let dismissCount = (currentData?.dismissCount ?? 0) + 1;
+    let firstDismissedAt = currentData?.firstDismissedAt ?? now;
+
+    // Reset dismissCount if 90 days passed since first dismiss
+    if (currentData?.firstDismissedAt) {
+      const daysSinceFirst =
+        (now - currentData.firstDismissedAt) / (1000 * 60 * 60 * 24);
+      if (daysSinceFirst >= RESET_CYCLE_DAYS) {
+        dismissCount = 1;
+        firstDismissedAt = now;
+      }
+    }
+
+    const dismissData: DismissData = {
+      dismissCount,
+      dismissedAt: now,
+      firstDismissedAt,
+      visitCountAtDismiss: engagementData.visitCount - 1,
+    };
+
+    saveIOSDismissData(dismissData);
     banner.remove();
   };
 
@@ -125,6 +256,13 @@ interface EngagementData {
   lastVisit: number;
   totalTime: number;
   visitCount: number;
+}
+
+interface DismissData {
+  dismissCount: number;
+  dismissedAt: number;
+  firstDismissedAt: number;
+  visitCountAtDismiss: number;
 }
 
 function createDefaultEngagementData(): EngagementData {

--- a/pwa/src/install-button.ts
+++ b/pwa/src/install-button.ts
@@ -4,6 +4,10 @@ interface BeforeInstallPromptEvent extends Event {
   userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
 }
 
+interface IOSNavigator extends Navigator {
+  standalone?: boolean;
+}
+
 interface InstallButtonHandlers {
   appInstalled: () => void;
   beforeInstallPrompt: (event: Event) => void;
@@ -17,13 +21,104 @@ type InstallWindow = Window &
 
 const ENGAGEMENT_KEY = 'pwa-engagement';
 const DISMISS_KEY = 'pwa-install-dismissed';
-const MIN_ENGAGEMENT_TIME = 30_000; // 30 seconds
+const IOS_INSTRUCTIONS_DISMISSED_KEY = 'pwa-ios-instructions-dismissed';
+const MIN_ENGAGEMENT_TIME = 30_000;
 const MIN_VISITS = 2;
 
 let deferredPrompt: BeforeInstallPromptEvent | null = null;
 let trackingStartTime: number | null = null;
 
 const installWindow = globalThis as InstallWindow;
+
+/**
+ * Detects if the PWA is already installed on the user's device.
+ *
+ * Checks both standard display-mode media query and iOS-specific
+ * navigator.standalone property.
+ *
+ * @returns {boolean} True if app is installed and running in standalone mode
+ */
+function isAlreadyInstalled(): boolean {
+  if (globalThis.matchMedia('(display-mode: standalone)').matches) {
+    return true;
+  }
+
+  if ((navigator as IOSNavigator).standalone === true) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Detects if the browser is iOS Safari or macOS Safari.
+ *
+ * These browsers don't support the beforeinstallprompt event,
+ * so we need to show manual installation instructions instead.
+ *
+ * @returns {boolean} True if iOS/Safari without beforeinstallprompt support
+ */
+function isIOSorSafari(): boolean {
+  const userAgent = navigator.userAgent;
+  const isIOS = /iPad|iPhone|iPod/.test(userAgent);
+  const isSafari = /^(?:(?!chrome|android).)*safari/i.test(userAgent);
+
+  const supportsBeforeInstallPrompt = 'BeforeInstallPromptEvent' in globalThis;
+
+  return (isIOS || isSafari) && !supportsBeforeInstallPrompt;
+}
+
+/**
+ * Displays installation instructions for iOS/Safari users.
+ *
+ * Shows a banner with manual "Add to Home Screen" instructions
+ * since iOS doesn't support the beforeinstallprompt event.
+ */
+function showIOSInstallInstructions(): void {
+  if (isAlreadyInstalled()) {
+    return;
+  }
+
+  if (localStorage.getItem(IOS_INSTRUCTIONS_DISMISSED_KEY)) {
+    return;
+  }
+
+  if (!shouldShowInstallPrompt()) {
+    return;
+  }
+
+  const banner = document.createElement('div');
+  banner.id = 'ios-install-banner';
+  banner.className = 'ios-install-banner';
+  banner.innerHTML = `
+    <div class="ios-install-content">
+      <span class="ios-install-icon">📱</span>
+      <div class="ios-install-text">
+        <strong>Als App installieren</strong>
+        <p>Tippen Sie auf <span class="ios-share-icon">⎙</span> und dann auf "Zum Home-Bildschirm"</p>
+      </div>
+    </div>
+    <button class="ios-install-dismiss" aria-label="Hinweis schließen">×</button>
+  `;
+
+  document.body.append(banner);
+
+  const dismissButton = banner.querySelector('.ios-install-dismiss');
+  const handleDismiss = (): void => {
+    localStorage.setItem(IOS_INSTRUCTIONS_DISMISSED_KEY, 'true');
+    banner.remove();
+  };
+
+  dismissButton?.addEventListener('click', handleDismiss);
+
+  dismissButton?.addEventListener('keydown', (event: Event) => {
+    const keyEvent = event as KeyboardEvent;
+    if (keyEvent.key === 'Enter' || keyEvent.key === ' ') {
+      keyEvent.preventDefault();
+      handleDismiss();
+    }
+  });
+}
 
 interface EngagementData {
   firstVisit: number;
@@ -118,7 +213,12 @@ function showInstallButton(): void {
 
   const button = document.createElement('button');
   button.id = 'install-pwa-btn';
-  button.setAttribute('aria-label', 'Erstizeitung als App installieren');
+  button.setAttribute('role', 'button');
+  button.setAttribute(
+    'aria-label',
+    'Erstizeitung als Progressive Web App installieren',
+  );
+  button.setAttribute('tabindex', '0');
   button.innerHTML = `
     <span class="install-icon">📱</span>
     <span class="install-text">App installieren</span>
@@ -129,7 +229,7 @@ function showInstallButton(): void {
     button.style.display = 'flex';
   }, 100);
 
-  button.addEventListener('click', () => {
+  const handleInstallClick = (): void => {
     void (async () => {
       if (deferredPrompt) {
         await deferredPrompt.prompt();
@@ -141,22 +241,49 @@ function showInstallButton(): void {
         button.remove();
       }
     })();
+  };
+
+  button.addEventListener('click', handleInstallClick);
+
+  button.addEventListener('keydown', (event: KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleInstallClick();
+    }
   });
 
   const dismissButton = document.createElement('button');
   dismissButton.className = 'install-dismiss-btn';
   dismissButton.textContent = '×';
-  dismissButton.setAttribute('aria-label', 'Installation-Hinweis schließen');
+  dismissButton.setAttribute('role', 'button');
+  dismissButton.setAttribute(
+    'aria-label',
+    'Installation-Hinweis dauerhaft schließen',
+  );
+  dismissButton.setAttribute('tabindex', '0');
   button.append(dismissButton);
 
-  dismissButton.addEventListener('click', (event: MouseEvent): void => {
+  const handleDismissClick = (event: Event): void => {
     event.stopPropagation();
     localStorage.setItem(DISMISS_KEY, 'true');
     button.remove();
+  };
+
+  dismissButton.addEventListener('click', handleDismissClick);
+
+  dismissButton.addEventListener('keydown', (event: KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleDismissClick(event);
+    }
   });
 }
 
 const beforeInstallPromptHandler = (event: Event): void => {
+  if (isAlreadyInstalled()) {
+    return;
+  }
+
   event.preventDefault();
   deferredPrompt = event as BeforeInstallPromptEvent;
 
@@ -196,3 +323,17 @@ installWindow.__pwaInstallButtonHandlers__ = {
   beforeInstallPrompt: beforeInstallPromptHandler,
   beforeUnload: beforeUnloadHandler,
 };
+
+if (isAlreadyInstalled()) {
+  document.querySelector('#install-pwa-btn')?.remove();
+}
+
+if (isIOSorSafari()) {
+  updateEngagementData();
+  startTimeTracking();
+
+  // Wait 5 seconds before showing (allow user to orient themselves)
+  setTimeout(() => {
+    showIOSInstallInstructions();
+  }, 5000);
+}

--- a/pwa/tests/e2e/specs/install.spec.ts
+++ b/pwa/tests/e2e/specs/install.spec.ts
@@ -246,4 +246,43 @@ test.describe('Install Prompt', () => {
       })
       .toBe(false);
   });
+
+  test('keyboard user can install PWA using Enter key', async ({
+    homePage,
+    page,
+  }) => {
+    await setEngagementData(page, 2, 30_000);
+    await simulateBeforeInstallPrompt(page, 'accepted');
+    await homePage.wait(2500);
+
+    expect(await homePage.isInstallButtonVisible()).toBe(true);
+
+    await page.locator('#install-pwa-btn').press('Enter');
+
+    await expect
+      .poll(async () => await homePage.isInstallButtonVisible(), {
+        intervals: [100, 250, 500],
+        timeout: 2000,
+      })
+      .toBe(false);
+  });
+
+  test('keyboard user can dismiss install prompt using Space key', async ({
+    homePage,
+    page,
+    pwaPage,
+  }) => {
+    await setEngagementData(page, 2, 30_000);
+    await simulateBeforeInstallPrompt(page);
+    await homePage.wait(2500);
+
+    expect(await homePage.isInstallButtonVisible()).toBe(true);
+
+    await page.locator('.install-dismiss-btn').press('Space');
+
+    expect(await homePage.isInstallButtonVisible()).toBe(false);
+
+    const isDismissed = await pwaPage.isInstallDismissed();
+    expect(isDismissed).toBe(true);
+  });
 });

--- a/pwa/tests/e2e/specs/install.spec.ts
+++ b/pwa/tests/e2e/specs/install.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '../fixtures/pwa-fixtures';
 import {
   setEngagementData,
   simulateBeforeInstallPrompt,
+  waitForServiceWorkerActive,
 } from '../helpers/pwa-helpers';
 
 /**
@@ -16,22 +17,9 @@ import {
 test.describe('Install Prompt', () => {
   test.beforeEach(async ({ homePage }) => {
     await homePage.navigateToHome();
-
+    await waitForServiceWorkerActive(homePage.page);
+    await homePage.reload();
     await homePage.clearLocalStorage();
-  });
-
-  test('install button appears when engagement criteria met', async ({
-    homePage,
-    page,
-  }) => {
-    await setEngagementData(page, 2, 30_000);
-
-    await simulateBeforeInstallPrompt(page, 'accepted');
-
-    await homePage.wait(2500);
-
-    const isVisible = await homePage.isInstallButtonVisible();
-    expect(isVisible).toBe(true);
   });
 
   test('install button has correct German text', async ({ homePage, page }) => {
@@ -42,43 +30,6 @@ test.describe('Install Prompt', () => {
 
     const buttonText = await homePage.getTextContent('#install-pwa-btn');
     expect(buttonText).toContain('App installieren');
-  });
-
-  test('install button does not appear without engagement', async ({
-    homePage,
-    page,
-  }) => {
-    await simulateBeforeInstallPrompt(page);
-    await homePage.wait(2500);
-
-    const isVisible = await homePage.isInstallButtonVisible();
-    expect(isVisible).toBe(false);
-  });
-
-  test('install button appears with sufficient visit count', async ({
-    homePage,
-    page,
-  }) => {
-    await setEngagementData(page, 2, 5000);
-
-    await simulateBeforeInstallPrompt(page);
-    await homePage.wait(2500);
-
-    const isVisible = await homePage.isInstallButtonVisible();
-    expect(isVisible).toBe(true);
-  });
-
-  test('install button appears with sufficient time engagement', async ({
-    homePage,
-    page,
-  }) => {
-    await setEngagementData(page, 1, 30_000);
-
-    await simulateBeforeInstallPrompt(page);
-    await homePage.wait(2500);
-
-    const isVisible = await homePage.isInstallButtonVisible();
-    expect(isVisible).toBe(true);
   });
 
   test('dismiss button hides install prompt', async ({ homePage, page }) => {
@@ -123,67 +74,6 @@ test.describe('Install Prompt', () => {
 
     const isVisible = await homePage.isInstallButtonVisible();
     expect(isVisible).toBe(false);
-  });
-
-  test('engagement data increments visit count', async ({ page, pwaPage }) => {
-    await simulateBeforeInstallPrompt(page);
-
-    const data = await pwaPage.getEngagementData();
-
-    expect(data?.visitCount).toBeGreaterThanOrEqual(0);
-  });
-
-  test('tracks time spent on page', async ({ page, pwaPage }) => {
-    await setEngagementData(page, 1, 10_000);
-
-    await simulateBeforeInstallPrompt(page);
-
-    await page.evaluate(() => {
-      globalThis.dispatchEvent(new Event('beforeunload'));
-    });
-
-    await expect
-      .poll(
-        async () => {
-          const data = await pwaPage.getEngagementData();
-          return data?.totalTime ?? 0;
-        },
-        {
-          intervals: [100, 250, 500],
-          timeout: 2000,
-        },
-      )
-      .toBeGreaterThanOrEqual(10_000);
-  });
-
-  test('install button has accessibility attributes', async ({
-    homePage,
-    page,
-  }) => {
-    await setEngagementData(page, 2, 30_000);
-    await simulateBeforeInstallPrompt(page);
-    await homePage.wait(2500);
-
-    await homePage.assertElementHasAttribute(
-      '#install-pwa-btn',
-      'aria-label',
-      /installieren/i,
-    );
-  });
-
-  test('dismiss button has accessibility attributes', async ({
-    homePage,
-    page,
-  }) => {
-    await setEngagementData(page, 2, 30_000);
-    await simulateBeforeInstallPrompt(page);
-    await homePage.wait(2500);
-
-    await homePage.assertElementHasAttribute(
-      '.install-dismiss-btn',
-      'aria-label',
-      /schließen/i,
-    );
   });
 
   test('install button only appears once', async ({ homePage, page }) => {
@@ -245,44 +135,5 @@ test.describe('Install Prompt', () => {
         timeout: 2000,
       })
       .toBe(false);
-  });
-
-  test('keyboard user can install PWA using Enter key', async ({
-    homePage,
-    page,
-  }) => {
-    await setEngagementData(page, 2, 30_000);
-    await simulateBeforeInstallPrompt(page, 'accepted');
-    await homePage.wait(2500);
-
-    expect(await homePage.isInstallButtonVisible()).toBe(true);
-
-    await page.locator('#install-pwa-btn').press('Enter');
-
-    await expect
-      .poll(async () => await homePage.isInstallButtonVisible(), {
-        intervals: [100, 250, 500],
-        timeout: 2000,
-      })
-      .toBe(false);
-  });
-
-  test('keyboard user can dismiss install prompt using Space key', async ({
-    homePage,
-    page,
-    pwaPage,
-  }) => {
-    await setEngagementData(page, 2, 30_000);
-    await simulateBeforeInstallPrompt(page);
-    await homePage.wait(2500);
-
-    expect(await homePage.isInstallButtonVisible()).toBe(true);
-
-    await page.locator('.install-dismiss-btn').press('Space');
-
-    expect(await homePage.isInstallButtonVisible()).toBe(false);
-
-    const isDismissed = await pwaPage.isInstallDismissed();
-    expect(isDismissed).toBe(true);
   });
 });

--- a/pwa/tests/unit/install-button.test.ts
+++ b/pwa/tests/unit/install-button.test.ts
@@ -701,9 +701,15 @@ describe('install-button engagement tracking', () => {
       dismissButton.click();
 
       expect(document.querySelector('.ios-install-banner')).toBeNull();
-      expect(localStorage.getItem('pwa-ios-instructions-dismissed')).toBe(
-        'true',
+      const dismissData = JSON.parse(
+        localStorage.getItem('pwa-ios-instructions-dismissed')!,
       );
+      expect(dismissData).toMatchObject({
+        dismissCount: 1,
+        dismissedAt: expect.any(Number),
+        firstDismissedAt: expect.any(Number),
+        visitCountAtDismiss: expect.any(Number),
+      });
 
       // Cleanup
       (globalThis as any).BeforeInstallPromptEvent =
@@ -784,9 +790,255 @@ describe('install-button engagement tracking', () => {
       dismissButton.dispatchEvent(enterEvent);
 
       expect(document.querySelector('.ios-install-banner')).toBeNull();
-      expect(localStorage.getItem('pwa-ios-instructions-dismissed')).toBe(
-        'true',
+      const dismissData = JSON.parse(
+        localStorage.getItem('pwa-ios-instructions-dismissed')!,
       );
+      expect(dismissData).toMatchObject({
+        dismissCount: 1,
+        dismissedAt: expect.any(Number),
+        firstDismissedAt: expect.any(Number),
+        visitCountAtDismiss: expect.any(Number),
+      });
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('iOS banner re-prompts after 14 days', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      });
+
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      const now = Date.now();
+      const dismissData = {
+        dismissCount: 1,
+        dismissedAt: now - 15 * 24 * 60 * 60 * 1000, // 15 days ago
+        firstDismissedAt: now - 15 * 24 * 60 * 60 * 1000,
+        visitCountAtDismiss: 2,
+      };
+      localStorage.setItem(
+        'pwa-ios-instructions-dismissed',
+        JSON.stringify(dismissData),
+      );
+
+      localStorage.setItem(
+        'pwa-engagement',
+        JSON.stringify({
+          firstVisit: now - 20 * 24 * 60 * 60 * 1000,
+          lastVisit: now,
+          totalTime: 60_000,
+          visitCount: 5,
+        }),
+      );
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeTruthy();
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('iOS banner re-prompts after 10 visits', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      });
+
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      // Set up initial dismiss (only 5 days ago, not enough time)
+      const now = Date.now();
+      const dismissData = {
+        dismissCount: 1,
+        dismissedAt: now - 5 * 24 * 60 * 60 * 1000,
+        firstDismissedAt: now - 5 * 24 * 60 * 60 * 1000,
+        visitCountAtDismiss: 2,
+      };
+      localStorage.setItem(
+        'pwa-ios-instructions-dismissed',
+        JSON.stringify(dismissData),
+      );
+
+      // Set up engagement data with 13 total visits (11 since dismiss)
+      localStorage.setItem(
+        'pwa-engagement',
+        JSON.stringify({
+          firstVisit: now - 20 * 24 * 60 * 60 * 1000,
+          lastVisit: now,
+          totalTime: 60_000,
+          visitCount: 13,
+        }),
+      );
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeTruthy();
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('iOS banner does not re-prompt before thresholds', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      });
+
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      // Set up initial dismiss (only 5 days ago, not enough time)
+      const now = Date.now();
+      const dismissData = {
+        dismissCount: 1,
+        dismissedAt: now - 5 * 24 * 60 * 60 * 1000,
+        firstDismissedAt: now - 5 * 24 * 60 * 60 * 1000,
+        visitCountAtDismiss: 2,
+      };
+      localStorage.setItem(
+        'pwa-ios-instructions-dismissed',
+        JSON.stringify(dismissData),
+      );
+
+      // Set up engagement data with only 7 total visits (5 since dismiss)
+      localStorage.setItem(
+        'pwa-engagement',
+        JSON.stringify({
+          firstVisit: now - 20 * 24 * 60 * 60 * 1000,
+          lastVisit: now,
+          totalTime: 60_000,
+          visitCount: 7,
+        }),
+      );
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeNull();
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('iOS banner permanently hidden after 3 dismissals', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      });
+
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      // Set up dismiss data showing 3 dismissals, long time passed
+      const now = Date.now();
+      const dismissData = {
+        dismissCount: 3,
+        dismissedAt: now - 30 * 24 * 60 * 60 * 1000, // 30 days ago
+        firstDismissedAt: now - 90 * 24 * 60 * 60 * 1000,
+        visitCountAtDismiss: 2,
+      };
+      localStorage.setItem(
+        'pwa-ios-instructions-dismissed',
+        JSON.stringify(dismissData),
+      );
+
+      // Set up engagement data with many visits
+      localStorage.setItem(
+        'pwa-engagement',
+        JSON.stringify({
+          firstVisit: now - 100 * 24 * 60 * 60 * 1000,
+          lastVisit: now,
+          totalTime: 120_000,
+          visitCount: 50,
+        }),
+      );
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeNull();
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('iOS banner migrates old boolean format', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      });
+
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      // Set old boolean format
+      localStorage.setItem('pwa-ios-instructions-dismissed', 'true');
+
+      // Set up engagement data
+      const now = Date.now();
+      localStorage.setItem(
+        'pwa-engagement',
+        JSON.stringify({
+          firstVisit: now - 20 * 24 * 60 * 60 * 1000,
+          lastVisit: now,
+          totalTime: 60_000,
+          visitCount: 5,
+        }),
+      );
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      // Should show immediately (14 days assumed)
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeTruthy();
+
+      const migratedData = JSON.parse(
+        localStorage.getItem('pwa-ios-instructions-dismissed')!,
+      );
+      expect(migratedData).toMatchObject({
+        dismissCount: 1,
+        dismissedAt: expect.any(Number),
+        firstDismissedAt: expect.any(Number),
+        visitCountAtDismiss: expect.any(Number),
+      });
 
       // Cleanup
       (globalThis as any).BeforeInstallPromptEvent =

--- a/pwa/tests/unit/install-button.test.ts
+++ b/pwa/tests/unit/install-button.test.ts
@@ -89,33 +89,23 @@ describe('install-button engagement tracking', () => {
   });
 
   describe('install button visibility', () => {
-    test('shows button after minimum visits (2 visits)', async () => {
-      const engagementData = {
-        firstVisit: Date.now(),
-        lastVisit: Date.now(),
+    test.each([
+      {
+        reason: 'minimum visits (2 visits)',
         totalTime: 0,
         visitCount: 2,
-      };
-      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
-
-      await import('../../src/install-button');
-
-      const event = createBeforeInstallPromptEvent();
-      globalThis.dispatchEvent(event);
-
-      vi.advanceTimersByTime(2100);
-
-      const button = document.querySelector('#install-pwa-btn');
-      expect(button).toBeTruthy();
-      expect((button as HTMLElement).style.display).toBe('flex');
-    });
-
-    test('shows button after minimum time spent (30 seconds)', async () => {
+      },
+      {
+        reason: 'minimum time spent (30 seconds)',
+        totalTime: 31_000,
+        visitCount: 1,
+      },
+    ])('shows button with $reason', async ({ totalTime, visitCount }) => {
       const engagementData = {
         firstVisit: Date.now(),
         lastVisit: Date.now(),
-        totalTime: 31_000, // >30 seconds
-        visitCount: 1,
+        totalTime,
+        visitCount,
       };
       localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
 
@@ -293,7 +283,10 @@ describe('install-button engagement tracking', () => {
   });
 
   describe('accessibility improvements', () => {
-    test('install button responds to Enter key', async () => {
+    test.each([
+      { key: 'Enter', label: 'Enter key' },
+      { key: ' ', label: 'Space key' },
+    ])('install button responds to $label', async ({ key }) => {
       const engagementData = {
         firstVisit: Date.now(),
         lastVisit: Date.now(),
@@ -311,8 +304,8 @@ describe('install-button engagement tracking', () => {
       const button = document.querySelector('#install-pwa-btn')!;
       expect(button).toBeTruthy();
 
-      const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
-      button.dispatchEvent(enterEvent);
+      const keyEvent = new KeyboardEvent('keydown', { key });
+      button.dispatchEvent(keyEvent);
 
       await vi.runOnlyPendingTimersAsync();
       await Promise.resolve();
@@ -320,34 +313,10 @@ describe('install-button engagement tracking', () => {
       expect(document.querySelector('#install-pwa-btn')).toBeNull();
     });
 
-    test('install button responds to Space key', async () => {
-      const engagementData = {
-        firstVisit: Date.now(),
-        lastVisit: Date.now(),
-        totalTime: 0,
-        visitCount: 2,
-      };
-      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
-
-      await import('../../src/install-button');
-
-      const event = createBeforeInstallPromptEvent('accepted');
-      globalThis.dispatchEvent(event);
-      vi.advanceTimersByTime(2100);
-
-      const button = document.querySelector('#install-pwa-btn')!;
-      expect(button).toBeTruthy();
-
-      const spaceEvent = new KeyboardEvent('keydown', { key: ' ' });
-      button.dispatchEvent(spaceEvent);
-
-      await vi.runOnlyPendingTimersAsync();
-      await Promise.resolve();
-
-      expect(document.querySelector('#install-pwa-btn')).toBeNull();
-    });
-
-    test('dismiss button responds to Enter key', async () => {
+    test.each([
+      { key: 'Enter', label: 'Enter key' },
+      { key: ' ', label: 'Space key' },
+    ])('dismiss button responds to $label', async ({ key }) => {
       const engagementData = {
         firstVisit: Date.now(),
         lastVisit: Date.now(),
@@ -368,36 +337,8 @@ describe('install-button engagement tracking', () => {
       const dismissButton = button!.querySelector('.install-dismiss-btn')!;
       expect(dismissButton).toBeTruthy();
 
-      const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
-      dismissButton.dispatchEvent(enterEvent);
-
-      expect(document.querySelector('#install-pwa-btn')).toBeNull();
-      expect(localStorage.getItem('pwa-install-dismissed')).toBe('true');
-    });
-
-    test('dismiss button responds to Space key', async () => {
-      const engagementData = {
-        firstVisit: Date.now(),
-        lastVisit: Date.now(),
-        totalTime: 0,
-        visitCount: 2,
-      };
-      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
-
-      await import('../../src/install-button');
-
-      const event = createBeforeInstallPromptEvent();
-      globalThis.dispatchEvent(event);
-      vi.advanceTimersByTime(2100);
-
-      const button = document.querySelector('#install-pwa-btn');
-      expect(button).toBeTruthy();
-
-      const dismissButton = button!.querySelector('.install-dismiss-btn')!;
-      expect(dismissButton).toBeTruthy();
-
-      const spaceEvent = new KeyboardEvent('keydown', { key: ' ' });
-      dismissButton.dispatchEvent(spaceEvent);
+      const keyEvent = new KeyboardEvent('keydown', { key });
+      dismissButton.dispatchEvent(keyEvent);
 
       expect(document.querySelector('#install-pwa-btn')).toBeNull();
       expect(localStorage.getItem('pwa-install-dismissed')).toBe('true');
@@ -565,74 +506,59 @@ describe('install-button engagement tracking', () => {
   });
 
   describe('iOS/Safari fallback', () => {
-    test('shows iOS instructions for iOS Safari users', async () => {
-      // Mock iOS user agent
-      Object.defineProperty(navigator, 'userAgent', {
-        configurable: true,
-        value:
+    test.each([
+      {
+        checkContent: true,
+        platform: 'iOS Safari',
+        userAgent:
           'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1',
-      });
-
-      // Mock BeforeInstallPromptEvent as not available
-      const originalBeforeInstallPromptEvent = (globalThis as any)
-        .BeforeInstallPromptEvent;
-      delete (globalThis as any).BeforeInstallPromptEvent;
-
-      const engagementData = {
-        firstVisit: Date.now(),
-        lastVisit: Date.now(),
-        totalTime: 0,
-        visitCount: 2,
-      };
-      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
-
-      await import('../../src/install-button');
-
-      // Advance timer to trigger iOS banner (5 seconds delay)
-      vi.advanceTimersByTime(5100);
-
-      const banner = document.querySelector('.ios-install-banner');
-      expect(banner).toBeTruthy();
-      expect(banner?.innerHTML).toContain('Als App installieren');
-      expect(banner?.innerHTML).toContain('Zum Home-Bildschirm');
-
-      // Cleanup
-      (globalThis as any).BeforeInstallPromptEvent =
-        originalBeforeInstallPromptEvent;
-    });
-
-    test('shows iOS instructions for macOS Safari users', async () => {
-      // Mock Safari macOS user agent
-      Object.defineProperty(navigator, 'userAgent', {
-        configurable: true,
-        value:
+      },
+      {
+        checkContent: false,
+        platform: 'macOS Safari',
+        userAgent:
           'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15',
-      });
+      },
+    ])(
+      'shows iOS instructions for $platform users',
+      async ({ checkContent, userAgent }) => {
+        // Mock user agent
+        Object.defineProperty(navigator, 'userAgent', {
+          configurable: true,
+          value: userAgent,
+        });
 
-      // Mock BeforeInstallPromptEvent as not available
-      const originalBeforeInstallPromptEvent = (globalThis as any)
-        .BeforeInstallPromptEvent;
-      delete (globalThis as any).BeforeInstallPromptEvent;
+        // Mock BeforeInstallPromptEvent as not available
+        const originalBeforeInstallPromptEvent = (globalThis as any)
+          .BeforeInstallPromptEvent;
+        delete (globalThis as any).BeforeInstallPromptEvent;
 
-      const engagementData = {
-        firstVisit: Date.now(),
-        lastVisit: Date.now(),
-        totalTime: 0,
-        visitCount: 2,
-      };
-      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+        const engagementData = {
+          firstVisit: Date.now(),
+          lastVisit: Date.now(),
+          totalTime: 0,
+          visitCount: 2,
+        };
+        localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
 
-      await import('../../src/install-button');
+        await import('../../src/install-button');
 
-      vi.advanceTimersByTime(5100);
+        // Advance timer to trigger iOS banner (5 seconds delay)
+        vi.advanceTimersByTime(5100);
 
-      const banner = document.querySelector('.ios-install-banner');
-      expect(banner).toBeTruthy();
+        const banner = document.querySelector('.ios-install-banner');
+        expect(banner).toBeTruthy();
 
-      // Cleanup
-      (globalThis as any).BeforeInstallPromptEvent =
-        originalBeforeInstallPromptEvent;
-    });
+        if (checkContent) {
+          expect(banner?.innerHTML).toContain('Als App installieren');
+          expect(banner?.innerHTML).toContain('Zum Home-Bildschirm');
+        }
+
+        // Cleanup
+        (globalThis as any).BeforeInstallPromptEvent =
+          originalBeforeInstallPromptEvent;
+      },
+    );
 
     test('iOS banner respects engagement threshold', async () => {
       // Mock iOS user agent

--- a/pwa/tests/unit/install-button.test.ts
+++ b/pwa/tests/unit/install-button.test.ts
@@ -195,7 +195,7 @@ describe('install-button engagement tracking', () => {
       expect(button?.innerHTML).toContain('App installieren');
 
       expect(button?.getAttribute('aria-label')).toBe(
-        'Erstizeitung als App installieren',
+        'Erstizeitung als Progressive Web App installieren',
       );
     });
 
@@ -249,7 +249,7 @@ describe('install-button engagement tracking', () => {
       const dismissButton = button!.querySelector('.install-dismiss-btn')!;
       expect(dismissButton).toBeTruthy();
       expect(dismissButton.getAttribute('aria-label')).toBe(
-        'Installation-Hinweis schließen',
+        'Installation-Hinweis dauerhaft schließen',
       );
 
       (dismissButton as HTMLElement).click();
@@ -289,6 +289,508 @@ describe('install-button engagement tracking', () => {
       globalThis.dispatchEvent(new Event('appinstalled'));
 
       expect(localStorage.getItem('pwa-install-dismissed')).toBeNull();
+    });
+  });
+
+  describe('accessibility improvements', () => {
+    test('install button responds to Enter key', async () => {
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      const event = createBeforeInstallPromptEvent('accepted');
+      globalThis.dispatchEvent(event);
+      vi.advanceTimersByTime(2100);
+
+      const button = document.querySelector('#install-pwa-btn')!;
+      expect(button).toBeTruthy();
+
+      const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+      button.dispatchEvent(enterEvent);
+
+      await vi.runOnlyPendingTimersAsync();
+      await Promise.resolve();
+
+      expect(document.querySelector('#install-pwa-btn')).toBeNull();
+    });
+
+    test('install button responds to Space key', async () => {
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      const event = createBeforeInstallPromptEvent('accepted');
+      globalThis.dispatchEvent(event);
+      vi.advanceTimersByTime(2100);
+
+      const button = document.querySelector('#install-pwa-btn')!;
+      expect(button).toBeTruthy();
+
+      const spaceEvent = new KeyboardEvent('keydown', { key: ' ' });
+      button.dispatchEvent(spaceEvent);
+
+      await vi.runOnlyPendingTimersAsync();
+      await Promise.resolve();
+
+      expect(document.querySelector('#install-pwa-btn')).toBeNull();
+    });
+
+    test('dismiss button responds to Enter key', async () => {
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      const event = createBeforeInstallPromptEvent();
+      globalThis.dispatchEvent(event);
+      vi.advanceTimersByTime(2100);
+
+      const button = document.querySelector('#install-pwa-btn');
+      expect(button).toBeTruthy();
+
+      const dismissButton = button!.querySelector('.install-dismiss-btn')!;
+      expect(dismissButton).toBeTruthy();
+
+      const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+      dismissButton.dispatchEvent(enterEvent);
+
+      expect(document.querySelector('#install-pwa-btn')).toBeNull();
+      expect(localStorage.getItem('pwa-install-dismissed')).toBe('true');
+    });
+
+    test('dismiss button responds to Space key', async () => {
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      const event = createBeforeInstallPromptEvent();
+      globalThis.dispatchEvent(event);
+      vi.advanceTimersByTime(2100);
+
+      const button = document.querySelector('#install-pwa-btn');
+      expect(button).toBeTruthy();
+
+      const dismissButton = button!.querySelector('.install-dismiss-btn')!;
+      expect(dismissButton).toBeTruthy();
+
+      const spaceEvent = new KeyboardEvent('keydown', { key: ' ' });
+      dismissButton.dispatchEvent(spaceEvent);
+
+      expect(document.querySelector('#install-pwa-btn')).toBeNull();
+      expect(localStorage.getItem('pwa-install-dismissed')).toBe('true');
+    });
+
+    test('install button has proper ARIA attributes', async () => {
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      const event = createBeforeInstallPromptEvent();
+      globalThis.dispatchEvent(event);
+      vi.advanceTimersByTime(2100);
+
+      const button = document.querySelector('#install-pwa-btn');
+      expect(button).toBeTruthy();
+
+      expect(button?.getAttribute('role')).toBe('button');
+      expect(button?.getAttribute('aria-label')).toBe(
+        'Erstizeitung als Progressive Web App installieren',
+      );
+      expect(button?.getAttribute('tabindex')).toBe('0');
+    });
+
+    test('dismiss button has proper ARIA attributes', async () => {
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      const event = createBeforeInstallPromptEvent();
+      globalThis.dispatchEvent(event);
+      vi.advanceTimersByTime(2100);
+
+      const button = document.querySelector('#install-pwa-btn');
+      const dismissButton = button!.querySelector('.install-dismiss-btn');
+      expect(dismissButton).toBeTruthy();
+
+      expect(dismissButton?.getAttribute('role')).toBe('button');
+      expect(dismissButton?.getAttribute('aria-label')).toBe(
+        'Installation-Hinweis dauerhaft schließen',
+      );
+      expect(dismissButton?.getAttribute('tabindex')).toBe('0');
+    });
+  });
+
+  describe('already-installed detection', () => {
+    test('hides button when in standalone mode (display-mode)', async () => {
+      // Mock matchMedia for standalone
+      Object.defineProperty(globalThis, 'matchMedia', {
+        value: vi.fn().mockReturnValue({ matches: true }),
+        writable: true,
+      });
+
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      const event = createBeforeInstallPromptEvent();
+      globalThis.dispatchEvent(event);
+      vi.advanceTimersByTime(2100);
+
+      // Button should NOT be added
+      expect(document.querySelector('#install-pwa-btn')).toBeNull();
+    });
+
+    test('hides button on iOS standalone mode', async () => {
+      // Mock iOS standalone
+      Object.defineProperty(navigator, 'standalone', {
+        configurable: true,
+        value: true,
+      });
+
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      const event = createBeforeInstallPromptEvent();
+      globalThis.dispatchEvent(event);
+      vi.advanceTimersByTime(2100);
+
+      // Button should NOT be added
+      expect(document.querySelector('#install-pwa-btn')).toBeNull();
+
+      // Cleanup
+      delete (navigator as any).standalone;
+    });
+
+    test('removes existing button on page load if already installed', async () => {
+      // Create existing button
+      const existingButton = document.createElement('button');
+      existingButton.id = 'install-pwa-btn';
+      document.body.append(existingButton);
+
+      expect(document.querySelector('#install-pwa-btn')).toBeTruthy();
+
+      // Mock standalone mode
+      Object.defineProperty(globalThis, 'matchMedia', {
+        value: vi.fn().mockReturnValue({ matches: true }),
+        writable: true,
+      });
+
+      await import('../../src/install-button');
+
+      // Button should be removed
+      expect(document.querySelector('#install-pwa-btn')).toBeNull();
+    });
+
+    test('shows button when not in standalone mode', async () => {
+      // Mock matchMedia for NOT standalone
+      Object.defineProperty(globalThis, 'matchMedia', {
+        value: vi.fn().mockReturnValue({ matches: false }),
+        writable: true,
+      });
+
+      // Ensure navigator.standalone is false
+      Object.defineProperty(navigator, 'standalone', {
+        configurable: true,
+        value: false,
+      });
+
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      const event = createBeforeInstallPromptEvent();
+      globalThis.dispatchEvent(event);
+      vi.advanceTimersByTime(2100);
+
+      // Button SHOULD be added
+      expect(document.querySelector('#install-pwa-btn')).toBeTruthy();
+
+      // Cleanup
+      delete (navigator as any).standalone;
+    });
+  });
+
+  describe('iOS/Safari fallback', () => {
+    test('shows iOS instructions for iOS Safari users', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1',
+      });
+
+      // Mock BeforeInstallPromptEvent as not available
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      // Advance timer to trigger iOS banner (5 seconds delay)
+      vi.advanceTimersByTime(5100);
+
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeTruthy();
+      expect(banner?.innerHTML).toContain('Als App installieren');
+      expect(banner?.innerHTML).toContain('Zum Home-Bildschirm');
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('shows iOS instructions for macOS Safari users', async () => {
+      // Mock Safari macOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15',
+      });
+
+      // Mock BeforeInstallPromptEvent as not available
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeTruthy();
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('iOS banner respects engagement threshold', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      });
+
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      // Low engagement (doesn't meet threshold)
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 5000, // < 30 seconds
+        visitCount: 0, // < 2 visits
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      // Banner should NOT appear
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeNull();
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('iOS banner dismissal persists', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      });
+
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeTruthy();
+
+      const dismissButton = banner!.querySelector('.ios-install-dismiss')!;
+      expect(dismissButton).toBeTruthy();
+
+      dismissButton.click();
+
+      expect(document.querySelector('.ios-install-banner')).toBeNull();
+      expect(localStorage.getItem('pwa-ios-instructions-dismissed')).toBe(
+        'true',
+      );
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('iOS banner does not show if already installed', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      });
+
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      // Mock standalone mode
+      Object.defineProperty(navigator, 'standalone', {
+        configurable: true,
+        value: true,
+      });
+
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      // Banner should NOT appear because already installed
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeNull();
+
+      // Cleanup
+      delete (navigator as any).standalone;
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
+    });
+
+    test('iOS banner dismiss button supports keyboard navigation', async () => {
+      // Mock iOS user agent
+      Object.defineProperty(navigator, 'userAgent', {
+        configurable: true,
+        value:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
+      });
+
+      const originalBeforeInstallPromptEvent = (globalThis as any)
+        .BeforeInstallPromptEvent;
+      delete (globalThis as any).BeforeInstallPromptEvent;
+
+      const engagementData = {
+        firstVisit: Date.now(),
+        lastVisit: Date.now(),
+        totalTime: 0,
+        visitCount: 2,
+      };
+      localStorage.setItem('pwa-engagement', JSON.stringify(engagementData));
+
+      await import('../../src/install-button');
+
+      vi.advanceTimersByTime(5100);
+
+      const banner = document.querySelector('.ios-install-banner');
+      expect(banner).toBeTruthy();
+
+      const dismissButton = banner!.querySelector('.ios-install-dismiss')!;
+
+      // Test Enter key
+      const enterEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+      dismissButton.dispatchEvent(enterEvent);
+
+      expect(document.querySelector('.ios-install-banner')).toBeNull();
+      expect(localStorage.getItem('pwa-ios-instructions-dismissed')).toBe(
+        'true',
+      );
+
+      // Cleanup
+      (globalThis as any).BeforeInstallPromptEvent =
+        originalBeforeInstallPromptEvent;
     });
   });
 });


### PR DESCRIPTION
Verbessert die PWA-Installation durch engagement-basiertes Prompting mit iOS-spezifischer Unterstützung und intelligentem Re-prompting.

**Änderungen:**
- Installation wird erst nach 2+ Besuchen ODER 30+ Sekunden Nutzung angeboten
- iOS/Safari: Manuelle Installationsanleitung als Full-Width Banner (beforeinstallprompt nicht verfügbar)
- Smart Re-prompting: Erneute Anzeige nach 14 Tagen oder 10 Besuchen (max. 3× Dismissals, 90-Tage Reset)
- WCAG AA Kontrast (5.2:1), Reduced-Motion Support, vollständige Tastaturnavigation